### PR TITLE
docs: add migration notice banner to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # DCC-MCP
 
+> [!IMPORTANT]
+> **This project has been migrated to the [dcc-mcp organization](https://github.com/dcc-mcp).**
+> Please visit the new organization repositories for the latest development and updates:
+> - [dcc-mcp/dcc-mcp-core](https://github.com/dcc-mcp/dcc-mcp-core) — Core library
+> - [dcc-mcp/dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) — Maya integration
+> - [dcc-mcp/dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) — Blender integration
+> - [dcc-mcp/dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) — Houdini integration
+> - [dcc-mcp/dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) — 3ds Max integration
+> - [dcc-mcp/dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) — Photoshop integration
+> - [dcc-mcp/dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) — ZBrush integration
+> - [dcc-mcp/dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) — USD integration
+>
+> This repository will no longer receive active updates. Please update your references accordingly.
+
 <div align="center">
 
 [![PyPI version](https://badge.fury.io/py/dcc-mcp.svg)](https://badge.fury.io/py/dcc-mcp)

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,19 @@
 # DCC-MCP
 
+> [!IMPORTANT]
+> **本项目已全部迁移至 [dcc-mcp 组织](https://github.com/dcc-mcp) 下统一管理。**
+> 请访问新的组织仓库以获取最新开发和更新：
+> - [dcc-mcp/dcc-mcp-core](https://github.com/dcc-mcp/dcc-mcp-core) — 核心库
+> - [dcc-mcp/dcc-mcp-maya](https://github.com/dcc-mcp/dcc-mcp-maya) — Maya 集成
+> - [dcc-mcp/dcc-mcp-blender](https://github.com/dcc-mcp/dcc-mcp-blender) — Blender 集成
+> - [dcc-mcp/dcc-mcp-houdini](https://github.com/dcc-mcp/dcc-mcp-houdini) — Houdini 集成
+> - [dcc-mcp/dcc-mcp-3dsmax](https://github.com/dcc-mcp/dcc-mcp-3dsmax) — 3ds Max 集成
+> - [dcc-mcp/dcc-mcp-photoshop](https://github.com/dcc-mcp/dcc-mcp-photoshop) — Photoshop 集成
+> - [dcc-mcp/dcc-mcp-zbrush](https://github.com/dcc-mcp/dcc-mcp-zbrush) — ZBrush 集成
+> - [dcc-mcp/dcc-mcp-openusd](https://github.com/dcc-mcp/dcc-mcp-openusd) — USD 集成
+>
+> 此仓库将不再接收活跃更新，请相应更新您的引用。
+
 <div align="center">
 
 [![PyPI version](https://badge.fury.io/py/dcc-mcp.svg)](https://badge.fury.io/py/dcc-mcp)


### PR DESCRIPTION
## Summary

Add a prominent migration notice banner at the top of both \README.md\ and \README_zh.md\ informing visitors that this project has been migrated to the unified [dcc-mcp organization](https://github.com/dcc-mcp).

## Changes

- Added a GitHub-flavored markdown \[!IMPORTANT]\ callout banner to both README files
- The banner lists all the new organization repositories with links
- Informs users that this repo will no longer receive active updates